### PR TITLE
Feature/upload #31-#108

### DIFF
--- a/designer/assets/application.css
+++ b/designer/assets/application.css
@@ -6053,3 +6053,12 @@ polyline :after {
   border-top-color: transparent;
   background: transparent;
 }
+
+.govuk-checkboxes__input.disabled,
+.govuk-checkboxes__input.disabled + .govuk-checkboxes__label {
+  pointer-events: none;
+  cursor: default;
+}
+.govuk-checkboxes__input.disabled + .govuk-checkboxes__label {
+  opacity: 0.5;
+}

--- a/designer/client/component-type-edit.js
+++ b/designer/client/component-type-edit.js
@@ -33,6 +33,7 @@ class FieldEdit extends React.Component {
   render () {
     const { component } = this.props
     const options = component.options || {}
+    const isFileUploadField = component.type === 'FileUploadField'
 
     return (
       <div>
@@ -57,14 +58,21 @@ class FieldEdit extends React.Component {
           <textarea className='govuk-textarea' id='field-hint' name='hint'
             defaultValue={component.hint} rows='2' />
         </div>
-
         <div className='govuk-checkboxes govuk-form-group'>
           <div className='govuk-checkboxes__item'>
             <input className='govuk-checkboxes__input' id='field-options.required'
-              name='options.required' type='checkbox' defaultChecked={options.required === false}
-              onChange={(e) => this.checkOptionalBox(e)} />
+              name='options.required' type='checkbox' defaultChecked={isFileUploadField}
+              onChange={(e) => this.checkOptionalBox(e)}
+              disabled={isFileUploadField }/>
             <label className='govuk-label govuk-checkboxes__label'
               htmlFor='field-options.required'>Optional</label>
+            {isFileUploadField && (
+              <span className='govuk-hint govuk-checkboxes__label'>All file upload fields are optional to mitigate possible upload errors</span>
+            )}
+            {!isFileUploadField && (
+              <span className='govuk-hint'>The hint can include HTML</span>
+            )}
+
           </div>
         </div>
 

--- a/designer/client/component-type-edit.js
+++ b/designer/client/component-type-edit.js
@@ -20,6 +20,7 @@ class FieldEdit extends React.Component {
   constructor (props) {
     super(props)
     const { component } = this.props
+
     const options = component.options || {}
     this.state = {
       hidden: options.required !== false
@@ -32,8 +33,8 @@ class FieldEdit extends React.Component {
 
   render () {
     const { component } = this.props
-    const options = component.options || {}
     const isFileUploadField = component.type === 'FileUploadField'
+    const options = component.options || {}
 
     return (
       <div>
@@ -60,10 +61,10 @@ class FieldEdit extends React.Component {
         </div>
         <div className='govuk-checkboxes govuk-form-group'>
           <div className='govuk-checkboxes__item'>
-            <input className='govuk-checkboxes__input' id='field-options.required'
+            <input className={`govuk-checkboxes__input ${isFileUploadField ? 'disabled' : ''}`} id='field-options.required'
               name='options.required' type='checkbox' defaultChecked={isFileUploadField}
               onChange={(e) => this.checkOptionalBox(e)}
-              disabled={isFileUploadField }/>
+              />
             <label className='govuk-label govuk-checkboxes__label'
               htmlFor='field-options.required'>Optional</label>
             {isFileUploadField && (

--- a/designer/client/index.scss
+++ b/designer/client/index.scss
@@ -524,3 +524,15 @@ polyline {
 .token.entity {
   cursor: help;
 }
+
+.govuk-input__input {
+  &.disabled {
+    cursor: default;
+    pointer-events: none;
+    & +.govuk-checkboxes__label {
+      opacity: 0.5;
+    }
+  }
+}
+
+

--- a/engine/views/components/fileuploadfield.html
+++ b/engine/views/components/fileuploadfield.html
@@ -4,4 +4,9 @@
   {% if component.model.value %}
       <p class="govuk-body">You have already provided this file.</p>
   {% endif %}
+    <div class="govuk-error-summary govuk-border-green upload-dialog" aria-labelledby="success-summary-title" role="alert" tabindex="-1">
+        <h2 class="govuk-!-margin-0 govuk-heading-m" id="success-summary-title">
+            Your file was successfully selected
+        </h2>
+    </div>
 {% endmacro %}

--- a/runner/client/sass/_upload-dialog.scss
+++ b/runner/client/sass/_upload-dialog.scss
@@ -1,0 +1,9 @@
+@import "node_modules/govuk-frontend/govuk/helpers/colour";
+
+.upload-dialog {
+  display: none;
+}
+
+.govuk-border-green {
+  border-color: govuk-colour("green");
+}

--- a/runner/client/sass/application.scss
+++ b/runner/client/sass/application.scss
@@ -2,6 +2,7 @@
 @import "node_modules/accessible-autocomplete/src/autocomplete";
 @import "hmpo";
 @import "modal-dialog";
+@import "upload-dialog";
 
 .flash-card {
   .govuk-button {

--- a/runner/server/lib/documentUpload.js
+++ b/runner/server/lib/documentUpload.js
@@ -84,6 +84,20 @@ class UploadService {
       files = this.fileStreamsFromPayload(request.payload)
     }
 
+    /**
+     * @desc If there are no valid file(buffer)s, reassign any empty buffers with empty string
+     * allows bypassing of file upload for whatever reason it doesn't work.
+     */
+    if(!files.length) {
+      let fields = Object.entries(request.payload)
+      for(const field of fields) {
+        if(field[1]._data) {
+          request.payload[field[0]] = ""
+        }
+      }
+      return h.continue
+    }
+
     // files is an array of tuples containing key and value.
     // value may be an array of file data where multiple files have been uploaded
     for (const file of files) {

--- a/runner/server/lib/documentUpload.js
+++ b/runner/server/lib/documentUpload.js
@@ -76,7 +76,7 @@ class UploadService {
 
   async handleUploadRequest (request, h) {
     const { cacheService } = request.services([])
-    const state = cacheService.getState(request)
+    const state = await cacheService.getState(request)
     const originalFilenames = (state || {}).originalFilenames || {}
 
     let files = []
@@ -88,11 +88,12 @@ class UploadService {
      * @desc If there are no valid file(buffer)s, reassign any empty buffers with empty string
      * allows bypassing of file upload for whatever reason it doesn't work.
      */
-    if(!files.length) {
+    if (!files.length) {
       let fields = Object.entries(request.payload)
-      for(const field of fields) {
-        if(field[1]._data) {
-          request.payload[field[0]] = ""
+      for (const [key, value] of fields) {
+        if (value._data) {
+          let originalFilename = originalFilenames[key]
+          request.payload[key] = (originalFilename && originalFilename.location) || ""
         }
       }
       return h.continue

--- a/runner/server/public/static/upload-dialog.js
+++ b/runner/server/public/static/upload-dialog.js
@@ -1,0 +1,3 @@
+$("input[type='file']").on('change', function () {
+  $(this).parent().parent().find('.upload-dialog').show();
+})

--- a/runner/server/views/layout.html
+++ b/runner/server/views/layout.html
@@ -100,12 +100,12 @@
 
 {% block bodyEnd %}
   {% include "partials/modal-dialog.html" %}
-
   <script src="{{ assetPath }}/jquery-1.11.3.js"></script>
   <script src="{{ assetPath }}/all.js"></script>
   <script src="{{ assetPath }}/govuk-template.js"></script>
   <script src="{{ assetPath }}/dialog-polyfill.0.4.3.js"></script>
   <script src="{{ assetPath }}/modal-dialog.js"></script>
+  <script src="{{ assetPath }}/upload-dialog.js"></script>
 
   <script>
     $(document).ready(function () {


### PR DESCRIPTION
https://trello.com/c/2GEwnwFm
- [x] A user knows they have successfully selected an image

https://trello.com/c/Q2NrZ56X
- [x] user can click continue with no photo selected
- [x] make all file fields optional

**changes made**

- Designer
  - Disable 'optional' checkbox for FileUploadFields using a class (so options.required is still captured). Added some messaging "All file upload fields are optional to mitigate possible upload errors" 
  - I added styles in both places, just for whenever we add a css compiler for /designer..?
- Runner
  - If there are no valid file streams, reassign any values with `_data` with empty string
    - For anyone who has already uploaded, the use the previously uploaded location 
  - added upload-dialog.js. detecting changes on file input types, finding the closest (just in case there are multiple on a page) and select .show() the closest .upload-dialog (see engine change below)
- Engine
  - added the dialog to fileuploadfield component


should we disable ci..? 

