### PR TITLE
Alphabetical ordering of component types

### DIFF
--- a/designer/client/component-create.js
+++ b/designer/client/component-create.js
@@ -38,9 +38,10 @@ class ComponentCreate extends React.Component {
             <select className='govuk-select' id='type' name='type' required
               onChange={e => this.setState({ component: { type: e.target.value } })}>
               <option />
-              {componentTypes.map(type => {
-                return <option key={type.name} value={type.name}>{type.title}</option>
-              })}
+              {componentTypes.sort((a, b) => (a.title??'').localeCompare(b.title))
+                .map(type => {
+                  return <option key={type.name} value={type.name}>{type.title}</option>
+                })}
             </select>
           </div>
 

--- a/designer/test/component-create.test.js
+++ b/designer/test/component-create.test.js
@@ -1,0 +1,44 @@
+import React from 'react'
+import { shallow } from 'enzyme'
+import * as Code from '@hapi/code'
+import * as Lab from '@hapi/lab'
+import ComponentCreate from '../client/component-create'
+import { Data } from '../client/model/data-model'
+
+const { expect } = Code
+const lab = Lab.script()
+exports.lab = lab
+const { suite, test } = lab
+
+suite('Component create', () => {
+  const data = new Data({})
+  const page = { path: '/1' }
+
+  test('Should display form with component types in alphabetical order', () => {
+    const wrapper = shallow(<ComponentCreate data={data} page={page} />)
+    const form = wrapper.find('form')
+
+    const componentTypeInput = form.find('select')
+    let lastDisplayedTitle = ''
+    componentTypeInput.find('options').forEach(type => {
+      expect(lastDisplayedTitle.localeCompare(type.title)).equal.to(-1)
+      lastDisplayedTitle = type.title
+    })
+
+    expect(wrapper.find('ComponentTypeEdit').exists()).to.equal(false)
+  })
+
+  test('Selecting a component type should display the ComponentTypeEdit component', () => {
+    const wrapper = shallow(<ComponentCreate data={data} page={page} />)
+    const form = wrapper.find('form')
+
+    form.find('select').simulate('change', { target: { value: 'TextField' } })
+
+    const componentTypeEdit = wrapper.find('ComponentTypeEdit')
+    expect(componentTypeEdit.exists()).to.equal(true)
+    expect(componentTypeEdit.prop('page')).to.equal(page)
+    expect(componentTypeEdit.prop('component')).to.equal({ type: 'TextField' })
+    expect(componentTypeEdit.prop('data')).to.equal(data)
+    expect(Object.keys(componentTypeEdit.props()).length).to.equal(3)
+  })
+})


### PR DESCRIPTION
# Description

Alphabetical ordering of component types in create component
Also added tests for display of component create. Unfortunately
submit requires too much rework to support testing currently.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Unit tests of component-create.js
Click testing of create component

# Checklist:

- [X] My code follows the [javascript standard style](https://standardjs.com/)
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation and versioning
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I have rebased onto master and there are no code conflicts




