### PR TITLE
Wire condition builder into link-edit

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,7 +1,7 @@
 .circleci
 .idea
 */node_modules
-.senv
+.env
 .gitignore
 */Dockerfile
-*/xsREADME.md
+*/README.md

--- a/designer/.babelrc
+++ b/designer/.babelrc
@@ -6,6 +6,7 @@
   "exclude": ["node_modules/**"],
   "plugins": [
     "@babel/plugin-proposal-class-properties",
+    "@babel/plugin-proposal-private-methods",
     "@babel/plugin-syntax-dynamic-import",
     "@babel/plugin-transform-runtime"
   ]

--- a/designer/client/conditions/inline-condition-operators.js
+++ b/designer/client/conditions/inline-condition-operators.js
@@ -7,6 +7,12 @@ function withDefaults (param) {
   return Object.assign(param, defaultOperators)
 }
 
+const textBasedFieldCustomisations = {
+  'is longer than': lengthIs('>'),
+  'is shorter than': lengthIs('<'),
+  'has length': lengthIs('==')
+}
+
 export const customOperators = {
   'CheckboxesField': {
     contains: reverseInline('in'),
@@ -17,7 +23,10 @@ export const customOperators = {
     'is at most': inline('<='),
     'is less than': inline('<'),
     'is greater than': inline('>')
-  })
+  }),
+  TextField: withDefaults(textBasedFieldCustomisations),
+  MultilineTextField: withDefaults(textBasedFieldCustomisations),
+  EmailAddressField: withDefaults(textBasedFieldCustomisations)
 }
 
 export function getOperatorNames (fieldType) {
@@ -35,6 +44,12 @@ function getConditionals (fieldType) {
 function inline (operator) {
   return {
     expression: (field, value) => `${field.name} ${operator} ${formatValue(field.type, value)}`
+  }
+}
+
+function lengthIs (operator) {
+  return {
+    expression: (field, value) => `length(${field.name}) ${operator} ${value}`
   }
 }
 

--- a/designer/client/conditions/inline-conditions-definition.js
+++ b/designer/client/conditions/inline-conditions-definition.js
@@ -131,8 +131,8 @@ class InlineConditionsDefinition extends React.Component {
             onChange={this.onChangeField}>
             <option />
             {
-              Object.values(this.props.fields).map(field =>
-                <option key={field.name} value={field.name}>{field.label}</option>)
+              Object.values(this.props.fields).map((field, index) =>
+                <option key={`${field.propertyPath}-${index}`} value={field.name}>{field.label}</option>)
             }
           </select>
 

--- a/designer/client/conditions/inline-conditions.js
+++ b/designer/client/conditions/inline-conditions.js
@@ -35,7 +35,7 @@ class InlineConditions extends React.Component {
     const inputs = path ? data.inputsAccessibleAt(path) : data.allInputs()
     return inputs
       .map(input => ({
-        label: input.title,
+        label: input.displayName,
         name: input.propertyPath,
         type: input.type,
         values: (data.listFor(input)??{}).items

--- a/designer/client/conditions/select-conditions.js
+++ b/designer/client/conditions/select-conditions.js
@@ -8,7 +8,8 @@ class SelectConditions extends React.Component {
 
     this.state = {
       fields: this.fieldsForPath(props.path),
-      inline: !props.data.hasConditions
+      inline: !props.data.hasConditions,
+      selectedCondition: props.selectedCondition
     }
   }
 
@@ -63,7 +64,7 @@ class SelectConditions extends React.Component {
   onCancelInlineCondition = () => {
     this.setState({
       inline: !this.props.data.hasConditions,
-      selectedCondition: null
+      selectedCondition: this.props.selectedCondition
     })
   }
 

--- a/designer/client/link-edit.js
+++ b/designer/client/link-edit.js
@@ -1,5 +1,7 @@
 import React from 'react'
 import { clone } from './helpers'
+import SelectConditions from './conditions/select-conditions'
+import InlineConditionHelpers from './conditions/inline-condition-helpers'
 
 class LinkEdit extends React.Component {
   constructor (props) {
@@ -17,25 +19,16 @@ class LinkEdit extends React.Component {
     }
   }
 
-  onSubmit = e => {
+  onSubmit = async e => {
     e.preventDefault()
-    const form = e.target
-    const formData = new window.FormData(form)
-    const condition = formData.get('condition')
+    const { link, page, selectedCondition, conditions } = this.state
     const { data } = this.props
-    const { link, page } = this.state
 
     const copy = clone(data)
-    const copyPage = copy.findPage(page.path)
-    const copyLink = copyPage.next.find(n => n.path === link.path)
+    const conditionResult = await InlineConditionHelpers.storeConditionIfNecessary(copy, selectedCondition, conditions)
+    const updatedData = conditionResult.data.updateLink(page.path, link.path, conditionResult.condition)
 
-    if (condition) {
-      copyLink.condition = condition
-    } else {
-      delete copyLink.condition
-    }
-
-    data.save(copy)
+    data.save(updatedData)
       .then(data => {
         this.props.onEdit({ data })
       })
@@ -70,14 +63,14 @@ class LinkEdit extends React.Component {
 
   render () {
     const { data, edge } = this.props
-    const { pages, conditions } = data
+    const { pages } = data
     const { link } = this.state
 
     return (
       <form onSubmit={e => this.onSubmit(e)} autoComplete='off'>
         <div className='govuk-form-group'>
           <label className='govuk-label govuk-label--s' htmlFor='link-source'>From</label>
-          <select defaultValue={edge.source} className='govuk-select' id='link-source' disabled>
+          <select value={edge.source} className='govuk-select' id='link-source' disabled>
             <option />
             {pages.map(page => (<option key={page.path} value={page.path}>{page.title}</option>))}
           </select>
@@ -85,27 +78,25 @@ class LinkEdit extends React.Component {
 
         <div className='govuk-form-group'>
           <label className='govuk-label govuk-label--s' htmlFor='link-target'>To</label>
-          <select defaultValue={edge.target} className='govuk-select' id='link-target' disabled>
+          <select value={edge.target} className='govuk-select' id='link-target' disabled>
             <option />
             {pages.map(page => (<option key={page.path} value={page.path}>{page.title}</option>))}
           </select>
         </div>
 
-        <div className='govuk-form-group'>
-          <label className='govuk-label govuk-label--s' htmlFor='link-condition'>Condition (optional)</label>
-          <span id='link-condition-hint' className='govuk-hint'>
-            The link will only be used if the expression evaluates to true.
-          </span>
-          <select className='govuk-select' id='link-condition' name='condition' defaultValue={link.condition} aria-describedby='link-condition-hint'>
-            <option value='' />
-            {conditions.map(condition => (<option key={condition.name} value={condition.name}>{condition.displayName}</option>))}
-          </select>
-        </div>
+        <SelectConditions data={data} path={edge.source} selectedCondition={link.condition} conditionsChange={this.saveConditions} />
 
         <button className='govuk-button' type='submit'>Save</button>&nbsp;
         <button className='govuk-button' type='button' onClick={this.onClickDelete}>Delete</button>
       </form>
     )
+  }
+
+  saveConditions = (conditions, selectedCondition) => {
+    this.setState({
+      conditions: conditions,
+      selectedCondition: selectedCondition
+    })
   }
 }
 

--- a/designer/client/model/data-model.js
+++ b/designer/client/model/data-model.js
@@ -74,6 +74,22 @@ export class Data {
     return this
   }
 
+  updateLink (from, to, condition) {
+    const fromPage = this.findPage(from)
+    const toPage = this.pages.find(p => p.path === to)
+    if (fromPage && toPage) {
+      const existingLink = fromPage.next?.find(it => it.path === to)
+      if (existingLink) {
+        if (condition) {
+          existingLink.condition = condition
+        } else {
+          delete existingLink.condition
+        }
+      }
+    }
+    return this
+  }
+
   addPage (page) {
     this.pages = this.pages || []
     this.pages.push(page)

--- a/designer/package-lock.json
+++ b/designer/package-lock.json
@@ -3288,15 +3288,6 @@
         }
       }
     },
-    "@rollup/plugin-json": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@rollup/plugin-json/-/plugin-json-4.1.0.tgz",
-      "integrity": "sha512-yfLbTdNS6amI/2OpmbiBoW12vngr5NW2jCJVZSBEz+H5KfUJZ2M7sDjk0U6GOOdCWFVScShte29o9NezJ53TPw==",
-      "dev": true,
-      "requires": {
-        "@rollup/pluginutils": "^3.0.8"
-      }
-    },
     "@rollup/plugin-node-resolve": {
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-8.1.0.tgz",

--- a/designer/package.json
+++ b/designer/package.json
@@ -30,6 +30,7 @@
   "devDependencies": {
     "@babel/core": "7.10.3",
     "@babel/plugin-proposal-class-properties": "7.10.1",
+    "@babel/plugin-proposal-private-methods": "^7.10.1",
     "@babel/plugin-transform-modules-amd": "^7.10.1",
     "@babel/plugin-transform-runtime": "7.10.1",
     "@babel/preset-env": "7.10.3",

--- a/designer/test/data-model.test.js
+++ b/designer/test/data-model.test.js
@@ -633,6 +633,171 @@ suite('data model', () => {
     })
   })
 
+  describe('update link', () => {
+    test('should remove a condition from a link to the next page', () => {
+      const data = new Data({
+        pages: [
+          {
+            name: 'page1',
+            section: 'section1',
+            path: '/1',
+            next: [{ path: '/2', condition: 'badgers' }],
+            components: [{ name: 'name1' }, { name: 'name2' }]
+          },
+          {
+            name: 'page2',
+            section: 'section1',
+            path: '/2',
+            components: [{ name: 'name3' }, { name: 'name4' }]
+          }
+        ]
+      })
+      const returned = data.updateLink('/1', '/2')
+      expect(returned.findPage(('/1'))).to.equal({
+        name: 'page1',
+        section: 'section1',
+        path: '/1',
+        next: [{ path: '/2' }],
+        components: [{ name: 'name1' }, { name: 'name2' }]
+      })
+      expect(returned.findPage(('/2'))).to.equal({
+        name: 'page2',
+        section: 'section1',
+        path: '/2',
+        components: [{ name: 'name3' }, { name: 'name4' }]
+      })
+    })
+
+    test('should add a condition to a link to the next page', () => {
+      const data = new Data({
+        pages: [
+          {
+            name: 'page1',
+            section: 'section1',
+            path: '/1',
+            next: [{ path: '/2' }],
+            components: [{ name: 'name1' }, { name: 'name2' }]
+          },
+          {
+            name: 'page2',
+            section: 'section1',
+            path: '/2',
+            components: [{ name: 'name3' }, { name: 'name4' }]
+          }
+        ],
+        conditions: [
+          { name: 'condition1' }
+        ]
+      })
+
+      const returned = data.updateLink('/1', '/2', 'condition1')
+
+      expect(returned.findPage(('/1'))).to.equal({
+        name: 'page1',
+        section: 'section1',
+        path: '/1',
+        next: [{ path: '/2', condition: 'condition1' }],
+        components: [{ name: 'name1' }, { name: 'name2' }]
+      })
+      expect(returned.findPage(('/2'))).to.equal({
+        name: 'page2',
+        section: 'section1',
+        path: '/2',
+        components: [{ name: 'name3' }, { name: 'name4' }]
+      })
+    })
+
+    test('should replace a condition on a link', () => {
+      const data = new Data({
+        pages: [
+          {
+            name: 'page1',
+            section: 'section1',
+            path: '/1',
+            next: [{ path: '/2', condition: 'badgers' }],
+            components: [{ name: 'name1' }, { name: 'name2' }]
+          },
+          {
+            name: 'page2',
+            section: 'section1',
+            path: '/2',
+            components: [{ name: 'name3' }, { name: 'name4' }]
+          }
+        ],
+        conditions: [
+          { name: 'condition1' }
+        ]
+      })
+
+      const returned = data.updateLink('/1', '/2', 'condition1')
+
+      expect(returned.findPage(('/1'))).to.equal({
+        name: 'page1',
+        section: 'section1',
+        path: '/1',
+        next: [{ path: '/2', condition: 'condition1' }],
+        components: [{ name: 'name1' }, { name: 'name2' }]
+      })
+      expect(returned.findPage(('/2'))).to.equal({
+        name: 'page2',
+        section: 'section1',
+        path: '/2',
+        components: [{ name: 'name3' }, { name: 'name4' }]
+      })
+    })
+
+    test('should do nothing if the specified link does not exist', () => {
+      const data = new Data({
+        pages: [
+          {
+            name: 'page1',
+            section: 'section1',
+            path: '/1',
+            next: [{ path: '/2' }],
+            components: [{ name: 'name1' }, { name: 'name2' }]
+          },
+          {
+            name: 'page2',
+            section: 'section1',
+            path: '/2',
+            components: [{ name: 'name3' }, { name: 'name4' }]
+          },
+          {
+            name: 'page3',
+            section: 'section1',
+            path: '/3',
+            components: [{ name: 'name5' }, { name: 'name6' }]
+          }
+        ],
+        conditions: [
+          { name: 'condition1' }
+        ]
+      })
+
+      const returned = data.updateLink('/1', '/3', 'condition1')
+
+      expect(returned.findPage(('/1'))).to.equal({
+        name: 'page1',
+        section: 'section1',
+        path: '/1',
+        next: [{ path: '/2' }],
+        components: [{ name: 'name1' }, { name: 'name2' }]
+      })
+      expect(returned.findPage(('/2'))).to.equal({
+        name: 'page2',
+        section: 'section1',
+        path: '/2',
+        components: [{ name: 'name3' }, { name: 'name4' }]
+      })
+      expect(returned.findPage(('/3'))).to.equal({
+        name: 'page3',
+        section: 'section1',
+        path: '/3',
+        components: [{ name: 'name5' }, { name: 'name6' }]
+      })
+    })
+  })
+
   describe('find page', () => {
     test('should return the page with the requested path if it exists', () => {
       const data = new Data({

--- a/designer/test/data-model.test.js
+++ b/designer/test/data-model.test.js
@@ -32,6 +32,271 @@ suite('data model', () => {
       ])
     })
 
+    test('should include hidden inputs from appropriate lists', () => {
+      const data = new Data({
+        pages: [
+          {
+            name: 'page1',
+            section: 'section1',
+            components: [{ name: 'name1', options: { list: 'badgerList' } }, { name: 'name2' }]
+          },
+          {
+            name: 'page2',
+            section: 'section1',
+            components: [{ name: 'name3' }, { name: 'name4' }]
+          }
+        ],
+        lists: [
+          {
+            name: 'anotherList',
+            title: 'Address Yes/No',
+            type: 'string',
+            items: [{
+              text: 'Yes',
+              value: 'true',
+              description: '',
+              condition: '',
+              conditional: {
+                components: [
+                  {
+                    'type': 'TextField',
+                    'name': 'buildingNameOrNumber',
+                    'title': 'Building name or number',
+                    'hint': '',
+                    'schema': {}
+                  }
+                ]
+              }
+            }]
+          },
+          {
+            name: 'badgerList',
+            title: 'Badgers are epic',
+            type: 'string',
+            items: [{
+              text: 'Something',
+              value: 'something',
+              description: '',
+              condition: '',
+              conditional: {
+                components: [
+                  {
+                    'name': 'myField'
+                  }
+                ]
+              }
+            }]
+          }
+        ]
+      })
+      expect(data.allInputs()).to.equal([
+        { name: 'name1', page: { name: 'page1', section: 'section1' }, options: { list: 'badgerList' }, propertyPath: 'section1.name1' },
+        { name: 'myField', page: { name: 'page1', section: 'section1' }, propertyPath: 'section1.myField' },
+        { name: 'name2', page: { name: 'page1', section: 'section1' }, propertyPath: 'section1.name2' },
+        { name: 'name3', page: { name: 'page2', section: 'section1' }, propertyPath: 'section1.name3' },
+        { name: 'name4', page: { name: 'page2', section: 'section1' }, propertyPath: 'section1.name4' }
+      ])
+    })
+
+    test('should not duplicate hidden inputs from lists if more than one component in the same page uses the same list', () => {
+      const data = new Data({
+        pages: [
+          {
+            name: 'page1',
+            section: 'section1',
+            components: [{ name: 'name1', options: { list: 'badgerList' } }, { name: 'name2', options: { list: 'badgerList' } }]
+          },
+          {
+            name: 'page2',
+            section: 'section1',
+            components: [{ name: 'name3' }, { name: 'name4' }]
+          }
+        ],
+        lists: [
+          {
+            name: 'anotherList',
+            title: 'Address Yes/No',
+            type: 'string',
+            items: [{
+              text: 'Yes',
+              value: 'true',
+              description: '',
+              condition: '',
+              conditional: {
+                components: [
+                  {
+                    'type': 'TextField',
+                    'name': 'buildingNameOrNumber',
+                    'title': 'Building name or number',
+                    'hint': '',
+                    'schema': {}
+                  }
+                ]
+              }
+            }]
+          },
+          {
+            name: 'badgerList',
+            title: 'Badgers are epic',
+            type: 'string',
+            items: [{
+              text: 'Something',
+              value: 'something',
+              description: '',
+              condition: '',
+              conditional: {
+                components: [
+                  {
+                    'name': 'myField'
+                  }
+                ]
+              }
+            }]
+          }
+        ]
+      })
+      expect(data.allInputs()).to.equal([
+        { name: 'name1', page: { name: 'page1', section: 'section1' }, options: { list: 'badgerList' }, propertyPath: 'section1.name1' },
+        { name: 'myField', page: { name: 'page1', section: 'section1' }, propertyPath: 'section1.myField' },
+        { name: 'name2', page: { name: 'page1', section: 'section1' }, options: { list: 'badgerList' }, propertyPath: 'section1.name2' },
+        { name: 'name3', page: { name: 'page2', section: 'section1' }, propertyPath: 'section1.name3' },
+        { name: 'name4', page: { name: 'page2', section: 'section1' }, propertyPath: 'section1.name4' }
+      ])
+    })
+
+    test('should not duplicate hidden inputs from lists if components in different pages with the same section use the same list', () => {
+      const data = new Data({
+        pages: [
+          {
+            name: 'page1',
+            section: 'section1',
+            components: [{ name: 'name1', options: { list: 'badgerList' } }, { name: 'name2' }]
+          },
+          {
+            name: 'page2',
+            section: 'section1',
+            components: [{ name: 'name3', options: { list: 'badgerList' } }, { name: 'name4' }]
+          }
+        ],
+        lists: [
+          {
+            name: 'anotherList',
+            title: 'Address Yes/No',
+            type: 'string',
+            items: [{
+              text: 'Yes',
+              value: 'true',
+              description: '',
+              condition: '',
+              conditional: {
+                components: [
+                  {
+                    'type': 'TextField',
+                    'name': 'buildingNameOrNumber',
+                    'title': 'Building name or number',
+                    'hint': '',
+                    'schema': {}
+                  }
+                ]
+              }
+            }]
+          },
+          {
+            name: 'badgerList',
+            title: 'Badgers are epic',
+            type: 'string',
+            items: [{
+              text: 'Something',
+              value: 'something',
+              description: '',
+              condition: '',
+              conditional: {
+                components: [
+                  {
+                    'name': 'myField'
+                  }
+                ]
+              }
+            }]
+          }
+        ]
+      })
+      expect(data.allInputs()).to.equal([
+        { name: 'name1', page: { name: 'page1', section: 'section1' }, options: { list: 'badgerList' }, propertyPath: 'section1.name1' },
+        { name: 'myField', page: { name: 'page1', section: 'section1' }, propertyPath: 'section1.myField' },
+        { name: 'name2', page: { name: 'page1', section: 'section1' }, propertyPath: 'section1.name2' },
+        { name: 'name3', page: { name: 'page2', section: 'section1' }, options: { list: 'badgerList' }, propertyPath: 'section1.name3' },
+        { name: 'name4', page: { name: 'page2', section: 'section1' }, propertyPath: 'section1.name4' }
+      ])
+    })
+
+    test('should return multiple of the same hidden input from lists if components in different pages with different sections use the same list', () => {
+      const data = new Data({
+        pages: [
+          {
+            name: 'page1',
+            section: 'section1',
+            components: [{ name: 'name1', options: { list: 'badgerList' } }, { name: 'name2' }]
+          },
+          {
+            name: 'page2',
+            section: 'section2',
+            components: [{ name: 'name3', options: { list: 'badgerList' } }, { name: 'name4' }]
+          }
+        ],
+        lists: [
+          {
+            name: 'anotherList',
+            title: 'Address Yes/No',
+            type: 'string',
+            items: [{
+              text: 'Yes',
+              value: 'true',
+              description: '',
+              condition: '',
+              conditional: {
+                components: [
+                  {
+                    'type': 'TextField',
+                    'name': 'buildingNameOrNumber',
+                    'title': 'Building name or number',
+                    'hint': '',
+                    'schema': {}
+                  }
+                ]
+              }
+            }]
+          },
+          {
+            name: 'badgerList',
+            title: 'Badgers are epic',
+            type: 'string',
+            items: [{
+              text: 'Something',
+              value: 'something',
+              description: '',
+              condition: '',
+              conditional: {
+                components: [
+                  {
+                    'name': 'myField'
+                  }
+                ]
+              }
+            }]
+          }
+        ]
+      })
+      expect(data.allInputs()).to.equal([
+        { name: 'name1', page: { name: 'page1', section: 'section1' }, options: { list: 'badgerList' }, propertyPath: 'section1.name1' },
+        { name: 'myField', page: { name: 'page1', section: 'section1' }, propertyPath: 'section1.myField' },
+        { name: 'name2', page: { name: 'page1', section: 'section1' }, propertyPath: 'section1.name2' },
+        { name: 'name3', page: { name: 'page2', section: 'section2' }, options: { list: 'badgerList' }, propertyPath: 'section2.name3' },
+        { name: 'myField', page: { name: 'page2', section: 'section2' }, propertyPath: 'section2.myField' },
+        { name: 'name4', page: { name: 'page2', section: 'section2' }, propertyPath: 'section2.name4' }
+      ])
+    })
+
     test('should ignore unnamed components', () => {
       const data = new Data({
         pages: [

--- a/designer/test/inline-condition-operators.test.js
+++ b/designer/test/inline-condition-operators.test.js
@@ -30,6 +30,27 @@ suite('Inline condition operators', () => {
     'CheckboxesField': {
       'contains': (field, value) => `'${value}' in ${field}`,
       'does not contain': (field, value) => `not ('${value}' in ${field})`
+    },
+    'TextField': {
+      'has length': (field, value) => `length(${field}) == ${value}`,
+      'is': (field, value) => `${field} == '${value}'`,
+      'is longer than': (field, value) => `length(${field}) > ${value}`,
+      'is not': (field, value) => `${field} != '${value}'`,
+      'is shorter than': (field, value) => `length(${field}) < ${value}`
+    },
+    'MultilineTextField': {
+      'has length': (field, value) => `length(${field}) == ${value}`,
+      'is': (field, value) => `${field} == '${value}'`,
+      'is longer than': (field, value) => `length(${field}) > ${value}`,
+      'is not': (field, value) => `${field} != '${value}'`,
+      'is shorter than': (field, value) => `length(${field}) < ${value}`
+    },
+    'EmailAddressField': {
+      'has length': (field, value) => `length(${field}) == ${value}`,
+      'is': (field, value) => `${field} == '${value}'`,
+      'is longer than': (field, value) => `length(${field}) > ${value}`,
+      'is not': (field, value) => `${field} != '${value}'`,
+      'is shorter than': (field, value) => `length(${field}) < ${value}`
     }
   }
 

--- a/designer/test/inline-conditions-definition.test.js
+++ b/designer/test/inline-conditions-definition.test.js
@@ -24,6 +24,7 @@ suite('Inline conditions definition section', () => {
   }
   const textFieldOperators = getOperatorNames('TextField')
   const numberFieldOperators = getOperatorNames('NumberField')
+  const isEqualToOperator = 'is'
   const path = '/'
 
   describe('when fields are present', () => {
@@ -262,11 +263,11 @@ suite('Inline conditions definition section', () => {
       test('Change field erases value but keeps operator if operator is still relevant', () => {
         const wrapper = shallow(<InlineConditionsDefinition saveCallback={saveCallback} expectsCoordinator={false} fields={expectedFields} />)
         wrapper.find('#cond-field').simulate('change', { target: { value: fields[0].name } })
-        wrapper.find('#cond-operator').simulate('change', { target: { value: textFieldOperators[0] } })
+        wrapper.find('#cond-operator').simulate('change', { target: { value: isEqualToOperator } })
         wrapper.find('#cond-value').simulate('change', { target: { value: 'M' } })
 
         assertFieldInputPresent(wrapper, fields, fields[0].name)
-        assertOperatorInputPresent(wrapper, textFieldOperators, textFieldOperators[0])
+        assertOperatorInputPresent(wrapper, textFieldOperators, isEqualToOperator)
         assertTextValueInputPresent(wrapper, 'M')
         assertSaveConditionLink(wrapper)
 

--- a/designer/test/inline-conditions-edit.test.js
+++ b/designer/test/inline-conditions-edit.test.js
@@ -21,8 +21,9 @@ const lab = Lab.script()
 exports.lab = lab
 const { beforeEach, describe, suite, test } = lab
 
+const isEqualToOperator = 'is'
+
 suite('Editing inline conditions', () => {
-  const textFieldOperators = getOperatorNames('TextField')
   const selectFieldOperators = getOperatorNames('SelectField')
   let exitCallback
   let saveCallback
@@ -47,7 +48,7 @@ suite('Editing inline conditions', () => {
       values: values
     }
   }
-  const firstCondition = new Condition(new Field(fields.field1.name, fields.field1.type, fields.field1.label), 'is', new Value('M'))
+  const firstCondition = new Condition(new Field(fields.field1.name, fields.field1.type, fields.field1.label), isEqualToOperator, new Value('M'))
   let conditions
 
   beforeEach(() => {
@@ -74,7 +75,7 @@ suite('Editing inline conditions', () => {
     })
 
     test('Clicking the edit link for a subsequent condition causes the field definition inputs to be pre-populated correctly', () => {
-      let condition = new Condition(new Field(fields.field2.name, fields.field2.type, fields.field2.label), textFieldOperators[0], new Value('N'), 'and')
+      let condition = new Condition(new Field(fields.field2.name, fields.field2.type, fields.field2.label), isEqualToOperator, new Value('N'), 'and')
       conditions.add(condition)
       const wrapper = shallow(<InlineConditionsEdit conditions={conditions} fields={fields} saveCallback={saveCallback} exitCallback={exitCallback} />)
       wrapper.find('#condition-1-edit').simulate('click')
@@ -84,12 +85,12 @@ suite('Editing inline conditions', () => {
     })
 
     test('Save condition callback results in an updated condition string and returns the users to an updated edit panel', () => {
-      conditions.add(new Condition(new Field(fields.field2.name, fields.field2.type, fields.field2.label), textFieldOperators[0], new Value('N'), 'and'))
+      conditions.add(new Condition(new Field(fields.field2.name, fields.field2.type, fields.field2.label), isEqualToOperator, new Value('N'), 'and'))
       const wrapper = shallow(<InlineConditionsEdit conditions={conditions} fields={fields} saveCallback={saveCallback} exitCallback={exitCallback} />)
       assertEditPanel(wrapper, [{ condition: '\'Something\' is \'M\'' }, { condition: 'and \'Something else\' is \'N\'' }])
       wrapper.find('#condition-1-edit').simulate('click')
 
-      wrapper.instance().saveCondition(new Condition(new Field(fields.field1.name, fields.field1.type, fields.field1.label), textFieldOperators[1], new Value('Badger'), 'or'))
+      wrapper.instance().saveCondition(new Condition(new Field(fields.field1.name, fields.field1.type, fields.field1.label), 'is not', new Value('Badger'), 'or'))
 
       assertEditPanel(wrapper, [{ condition: '\'Something\' is \'M\'' }, { condition: 'or \'Something\' is not \'Badger\'' }])
       expect(saveCallback.calledOnce).to.equal(true)
@@ -97,7 +98,7 @@ suite('Editing inline conditions', () => {
     })
 
     test('Grouping conditions combines them into a single condition which can be split but not edited', () => {
-      conditions.add(new Condition(new Field(fields.field2.name, fields.field2.type, fields.field2.label), textFieldOperators[0], new Value('N'), 'and'))
+      conditions.add(new Condition(new Field(fields.field2.name, fields.field2.type, fields.field2.label), isEqualToOperator, new Value('N'), 'and'))
       const wrapper = shallow(<InlineConditionsEdit conditions={conditions} fields={fields} saveCallback={saveCallback} exitCallback={exitCallback} />)
 
       expect(wrapper.find('#condition-0').exists()).to.equal(true)
@@ -117,7 +118,7 @@ suite('Editing inline conditions', () => {
     })
 
     test('should not group non-consecutive conditions', () => {
-      conditions.add(new Condition(new Field(fields.field2.name, fields.field2.type, fields.field2.label), textFieldOperators[0], new Value('N'), 'and'))
+      conditions.add(new Condition(new Field(fields.field2.name, fields.field2.type, fields.field2.label), isEqualToOperator, new Value('N'), 'and'))
       conditions.add(new Condition(new Field(fields.field3.name, fields.field3.type, fields.field3.label), selectFieldOperators[0], new Value(values[0].value, values[0].text), 'and'))
       const wrapper = shallow(<InlineConditionsEdit conditions={conditions} fields={fields} saveCallback={saveCallback} exitCallback={exitCallback} />)
 
@@ -138,10 +139,10 @@ suite('Editing inline conditions', () => {
     })
 
     test('should group multiple consecutive condition groups', () => {
-      conditions.add(new Condition(new Field(fields.field2.name, fields.field2.type, fields.field2.label), textFieldOperators[0], new Value('N'), 'or'))
+      conditions.add(new Condition(new Field(fields.field2.name, fields.field2.type, fields.field2.label), isEqualToOperator, new Value('N'), 'or'))
       conditions.add(new Condition(new Field(fields.field3.name, fields.field3.type, fields.field3.label), selectFieldOperators[0], new Value(values[0].value, values[0].text), 'and'))
       conditions.add(new Condition(new Field(fields.field3.name, fields.field3.type, fields.field3.label), selectFieldOperators[0], new Value(values[0].value, values[0].text), 'or'))
-      conditions.add(new Condition(new Field(fields.field2.name, fields.field2.type, fields.field2.label), textFieldOperators[0], new Value('Y'), 'and'))
+      conditions.add(new Condition(new Field(fields.field2.name, fields.field2.type, fields.field2.label), isEqualToOperator, new Value('Y'), 'and'))
       const wrapper = shallow(<InlineConditionsEdit conditions={conditions} fields={fields} saveCallback={saveCallback} exitCallback={exitCallback} />)
 
       expect(wrapper.find('#condition-0').exists()).to.equal(true)
@@ -170,7 +171,7 @@ suite('Editing inline conditions', () => {
     })
 
     test('splitting grouped conditions returns them to their original components', () => {
-      conditions.add(new Condition(new Field(fields.field2.name, fields.field2.type, fields.field2.label), textFieldOperators[0], new Value('N'), 'and'))
+      conditions.add(new Condition(new Field(fields.field2.name, fields.field2.type, fields.field2.label), isEqualToOperator, new Value('N'), 'and'))
       const wrapper = shallow(<InlineConditionsEdit conditions={conditions} fields={fields} saveCallback={saveCallback} exitCallback={exitCallback} />)
 
       expect(wrapper.find('#condition-0').exists()).to.equal(true)
@@ -194,7 +195,7 @@ suite('Editing inline conditions', () => {
     })
 
     test('removing selected conditions', () => {
-      conditions.add(new Condition(new Field(fields.field2.name, fields.field2.type, fields.field2.label), textFieldOperators[0], new Value('N'), 'and'))
+      conditions.add(new Condition(new Field(fields.field2.name, fields.field2.type, fields.field2.label), isEqualToOperator, new Value('N'), 'and'))
       conditions.add(new Condition(new Field(fields.field3.name, fields.field3.type, fields.field3.label), selectFieldOperators[0], new Value(values[0].value, values[0].text), 'and'))
       const wrapper = shallow(<InlineConditionsEdit conditions={conditions} fields={fields} saveCallback={saveCallback} exitCallback={exitCallback} />)
 
@@ -209,7 +210,7 @@ suite('Editing inline conditions', () => {
     })
 
     test('Should deselect conditions', () => {
-      conditions.add(new Condition(new Field(fields.field2.name, fields.field2.type, fields.field2.label), textFieldOperators[0], new Value('N'), 'and'))
+      conditions.add(new Condition(new Field(fields.field2.name, fields.field2.type, fields.field2.label), isEqualToOperator, new Value('N'), 'and'))
       conditions.add(new Condition(new Field(fields.field3.name, fields.field3.type, fields.field3.label), selectFieldOperators[0], new Value(values[0].value, values[0].text), 'and'))
       const wrapper = shallow(<InlineConditionsEdit conditions={conditions} fields={fields} saveCallback={saveCallback} exitCallback={exitCallback} />)
 
@@ -221,7 +222,7 @@ suite('Editing inline conditions', () => {
     })
 
     test('removing grouped conditions removes everything in the group', () => {
-      conditions.add(new Condition(new Field(fields.field2.name, fields.field2.type, fields.field2.label), textFieldOperators[0], new Value('N'), 'and'))
+      conditions.add(new Condition(new Field(fields.field2.name, fields.field2.type, fields.field2.label), isEqualToOperator, new Value('N'), 'and'))
       conditions.add(new Condition(new Field(fields.field3.name, fields.field3.type, fields.field3.label), selectFieldOperators[0], new Value(values[0].value, values[0].text), 'and'))
       const wrapper = shallow(<InlineConditionsEdit conditions={conditions} fields={fields} saveCallback={saveCallback} exitCallback={exitCallback} />)
 
@@ -240,7 +241,7 @@ suite('Editing inline conditions', () => {
     })
 
     test('removing last condition triggers exitCallback', () => {
-      conditions.add(new Condition(new Field(fields.field2.name, fields.field2.type, fields.field2.label), textFieldOperators[0], new Value('N'), 'and'))
+      conditions.add(new Condition(new Field(fields.field2.name, fields.field2.type, fields.field2.label), isEqualToOperator, new Value('N'), 'and'))
       const wrapper = shallow(<InlineConditionsEdit conditions={conditions} fields={fields} saveCallback={saveCallback} exitCallback={exitCallback} />)
 
       expect(wrapper.find('#condition-0').exists()).to.equal(true)

--- a/designer/test/inline-conditions.test.js
+++ b/designer/test/inline-conditions.test.js
@@ -43,9 +43,9 @@ suite('Inline conditions', () => {
 
     before(() => {
       fields = [
-        { propertyPath: 'field1', title: 'Something', type: 'TextField' },
-        { propertyPath: 'field2', title: 'Something else', type: 'TextField' },
-        { propertyPath: 'field3', title: 'Another thing', type: 'SelectField' }
+        { propertyPath: 'field1', displayName: 'Something', type: 'TextField' },
+        { propertyPath: 'field2', displayName: 'Something else', type: 'TextField' },
+        { propertyPath: 'field3', displayName: 'Another thing', type: 'SelectField' }
       ]
       expectedFields = {
         field1: {
@@ -118,7 +118,7 @@ suite('Inline conditions', () => {
     test('Clicking the cancel link should cancel any added conditions and partially completed inputs and trigger the cancel callback', () => {
       const wrapper = shallow(<InlineConditions data={data} path={path} conditionsChange={conditionsChange} cancelCallback={cancelCallback} />)
       let instance = wrapper.instance()
-      instance.saveCondition(new Condition(Field.from({ name: fields[0].propertyPath, type: fields[0].type, display: fields[0].title }), isEqualToOperator, new Value('N')))
+      instance.saveCondition(new Condition(Field.from({ name: fields[0].propertyPath, type: fields[0].type, display: fields[0].displayName }), isEqualToOperator, new Value('N')))
       expect(wrapper.find('#conditions-display').exists()).to.equal(true)
       const e = {}
       wrapper.find('#cancel-inline-conditions-link').simulate('click', e)
@@ -131,7 +131,7 @@ suite('Inline conditions', () => {
     test('Clicking the cancel link should succeed if there is no cancel callback', () => {
       const wrapper = shallow(<InlineConditions data={data} path={path} conditionsChange={conditionsChange} />)
       let instance = wrapper.instance()
-      instance.saveCondition(new Condition(Field.from({ name: fields[0].propertyPath, type: fields[0].type, display: fields[0].title }), isEqualToOperator, new Value('N')))
+      instance.saveCondition(new Condition(Field.from({ name: fields[0].propertyPath, type: fields[0].type, display: fields[0].displayName }), isEqualToOperator, new Value('N')))
       expect(wrapper.find('#conditions-display').exists()).to.equal(true)
       const e = {}
       wrapper.find('#cancel-inline-conditions-link').simulate('click', e)
@@ -195,7 +195,7 @@ suite('Inline conditions', () => {
 
       beforeEach(() => {
         conditions = new ConditionsModel()
-        conditions.add(new Condition(new Field(fields[0].propertyPath, fields[0].type, fields[0].title), isEqualToOperator, new Value('M')))
+        conditions.add(new Condition(new Field(fields[0].propertyPath, fields[0].type, fields[0].displayName), isEqualToOperator, new Value('M')))
       })
 
       test('Clicking the edit link causes editing view to be rendered', () => {
@@ -210,7 +210,7 @@ suite('Inline conditions', () => {
       test('edit callback should replace the conditions and leave in edit mode', () => {
         const wrapper = shallow(<InlineConditions data={data} path={path} conditionsChange={conditionsChange} cancelCallback={cancelCallback} />)
         wrapper.find('#add-item').simulate('click')
-        wrapper.instance().saveCondition(new Condition(new Field(fields[1].propertyPath, fields[1].type, fields[1].title), isEqualToOperator, new Value('N')))
+        wrapper.instance().saveCondition(new Condition(new Field(fields[1].propertyPath, fields[1].type, fields[1].displayName), isEqualToOperator, new Value('N')))
         wrapper.find('#edit-conditions-link').simulate('click')
         assertEditingHeaderGroupWithConditionString(wrapper, '\'Something else\' is \'N\'')
 

--- a/designer/test/inline-conditions.test.js
+++ b/designer/test/inline-conditions.test.js
@@ -6,7 +6,6 @@ import { assertLabel, assertLink, assertText } from './helpers/element-assertion
 import sinon from 'sinon'
 import InlineConditions from '../client/conditions/inline-conditions'
 import { Condition, ConditionsModel, Field, Value } from '../client/conditions/inline-condition-model'
-import { getOperatorNames } from '../client/conditions/inline-condition-operators'
 
 const { expect } = Code
 const lab = Lab.script()
@@ -19,7 +18,7 @@ suite('Inline conditions', () => {
     allInputs: sinon.stub(),
     listFor: sinon.stub()
   }
-  const textFieldOperators = getOperatorNames('TextField')
+  const isEqualToOperator = 'is'
   const path = '/'
   let conditionsChange
   let cancelCallback
@@ -119,7 +118,7 @@ suite('Inline conditions', () => {
     test('Clicking the cancel link should cancel any added conditions and partially completed inputs and trigger the cancel callback', () => {
       const wrapper = shallow(<InlineConditions data={data} path={path} conditionsChange={conditionsChange} cancelCallback={cancelCallback} />)
       let instance = wrapper.instance()
-      instance.saveCondition(new Condition(Field.from({ name: fields[0].propertyPath, type: fields[0].type, display: fields[0].title }), textFieldOperators[0], new Value('N')))
+      instance.saveCondition(new Condition(Field.from({ name: fields[0].propertyPath, type: fields[0].type, display: fields[0].title }), isEqualToOperator, new Value('N')))
       expect(wrapper.find('#conditions-display').exists()).to.equal(true)
       const e = {}
       wrapper.find('#cancel-inline-conditions-link').simulate('click', e)
@@ -132,7 +131,7 @@ suite('Inline conditions', () => {
     test('Clicking the cancel link should succeed if there is no cancel callback', () => {
       const wrapper = shallow(<InlineConditions data={data} path={path} conditionsChange={conditionsChange} />)
       let instance = wrapper.instance()
-      instance.saveCondition(new Condition(Field.from({ name: fields[0].propertyPath, type: fields[0].type, display: fields[0].title }), textFieldOperators[0], new Value('N')))
+      instance.saveCondition(new Condition(Field.from({ name: fields[0].propertyPath, type: fields[0].type, display: fields[0].title }), isEqualToOperator, new Value('N')))
       expect(wrapper.find('#conditions-display').exists()).to.equal(true)
       const e = {}
       wrapper.find('#cancel-inline-conditions-link').simulate('click', e)
@@ -196,7 +195,7 @@ suite('Inline conditions', () => {
 
       beforeEach(() => {
         conditions = new ConditionsModel()
-        conditions.add(new Condition(new Field(fields[0].propertyPath, fields[0].type, fields[0].title), textFieldOperators[0], new Value('M')))
+        conditions.add(new Condition(new Field(fields[0].propertyPath, fields[0].type, fields[0].title), isEqualToOperator, new Value('M')))
       })
 
       test('Clicking the edit link causes editing view to be rendered', () => {
@@ -211,7 +210,7 @@ suite('Inline conditions', () => {
       test('edit callback should replace the conditions and leave in edit mode', () => {
         const wrapper = shallow(<InlineConditions data={data} path={path} conditionsChange={conditionsChange} cancelCallback={cancelCallback} />)
         wrapper.find('#add-item').simulate('click')
-        wrapper.instance().saveCondition(new Condition(new Field(fields[1].propertyPath, fields[1].type, fields[1].title), textFieldOperators[0], new Value('N')))
+        wrapper.instance().saveCondition(new Condition(new Field(fields[1].propertyPath, fields[1].type, fields[1].title), isEqualToOperator, new Value('N')))
         wrapper.find('#edit-conditions-link').simulate('click')
         assertEditingHeaderGroupWithConditionString(wrapper, '\'Something else\' is \'N\'')
 

--- a/designer/test/link-edit.test.js
+++ b/designer/test/link-edit.test.js
@@ -1,0 +1,177 @@
+import React from 'react'
+import { shallow } from 'enzyme'
+import * as Code from '@hapi/code'
+import * as Lab from '@hapi/lab'
+import { Data } from '../client/model/data-model'
+import sinon from 'sinon'
+import { assertSelectInput } from './helpers/element-assertions'
+import InlineConditionHelpers from '../client/conditions/inline-condition-helpers'
+import LinkEdit from '../client/link-edit'
+
+const { expect } = Code
+const lab = Lab.script()
+exports.lab = lab
+const { suite, test, describe, beforeEach, afterEach } = lab
+
+suite('Link edit', () => {
+  describe('Editing a link which does not have a condition', () => {
+    const data = new Data({
+      pages: [
+        { path: '/1', title: 'Page 1', next: [ { path: '/2' } ] },
+        { path: '/2', title: 'Page 2' }
+      ],
+      conditions: [
+        { name: 'someCondition', displayName: 'My condition' },
+        { name: 'anotherCondition', displayName: 'Another condition' }
+      ]
+    })
+    const edge = {
+      source: '/1',
+      target: '/2'
+    }
+
+    test('Renders a form with expected inputs', () => {
+      const wrapper = shallow(<LinkEdit data={data} edge={edge} />)
+      const form = wrapper.find('form')
+
+      const fromInput = form.find('#link-source')
+      assertSelectInput(fromInput, 'link-source', [
+        { text: '' },
+        { value: '/1', text: 'Page 1' },
+        { value: '/2', text: 'Page 2' }
+      ], '/1')
+      expect(fromInput.prop('disabled')).to.equal(true)
+
+      const toInput = form.find('#link-target')
+      assertSelectInput(toInput, 'link-target', [
+        { text: '' },
+        { value: '/1', text: 'Page 1' },
+        { value: '/2', text: 'Page 2' }
+      ], '/2')
+      expect(toInput.prop('disabled')).to.equal(true)
+
+      const selectConditions = wrapper.find('SelectConditions')
+      expect(selectConditions.exists()).to.equal(true)
+      expect(selectConditions.prop('data')).to.equal(data)
+      expect(selectConditions.prop('path')).to.equal('/1')
+      expect(selectConditions.prop('selectedCondition')).to.equal(undefined)
+      expect(selectConditions.prop('conditionsChange')).to.equal(wrapper.instance().saveConditions)
+    })
+  })
+
+  describe('Editing a link which has a condition', () => {
+    const data = new Data({
+      pages: [
+        { path: '/1', title: 'Page 1', next: [ { path: '/2', condition: 'anotherCondition' } ] },
+        { path: '/2', title: 'Page 2' }
+      ],
+      conditions: [
+        { name: 'someCondition', displayName: 'My condition' },
+        { name: 'anotherCondition', displayName: 'Another condition' }
+      ]
+    })
+    const edge = {
+      source: '/1',
+      target: '/2'
+    }
+
+    test('Renders a form with expected inputs', () => {
+      const wrapper = shallow(<LinkEdit data={data} edge={edge} />)
+      const form = wrapper.find('form')
+
+      const fromInput = form.find('#link-source')
+      assertSelectInput(fromInput, 'link-source', [
+        { text: '' },
+        { value: '/1', text: 'Page 1' },
+        { value: '/2', text: 'Page 2' }
+      ], '/1')
+      expect(fromInput.prop('disabled')).to.equal(true)
+
+      const toInput = form.find('#link-target')
+      assertSelectInput(toInput, 'link-target', [
+        { text: '' },
+        { value: '/1', text: 'Page 1' },
+        { value: '/2', text: 'Page 2' }
+      ], '/2')
+      expect(toInput.prop('disabled')).to.equal(true)
+
+      const selectConditions = wrapper.find('SelectConditions')
+      expect(selectConditions.exists()).to.equal(true)
+      expect(selectConditions.prop('data')).to.equal(data)
+      expect(selectConditions.prop('path')).to.equal('/1')
+      expect(selectConditions.prop('selectedCondition')).to.equal('anotherCondition')
+      expect(selectConditions.prop('conditionsChange')).to.equal(wrapper.instance().saveConditions)
+    })
+  })
+
+  describe('submitting the form', () => {
+    const data = new Data({
+      pages: [
+        { path: '/1', title: 'Page 1', next: [ { path: '/2' } ] },
+        { path: '/2', title: 'Page 2' }
+      ],
+      conditions: [
+        { name: 'someCondition', displayName: 'My condition' },
+        { name: 'anotherCondition', displayName: 'Another condition' }
+      ]
+    })
+    const edge = {
+      source: '/1',
+      target: '/2'
+    }
+    let storeConditionStub
+
+    beforeEach(function () {
+      storeConditionStub = sinon.stub(InlineConditionHelpers, 'storeConditionIfNecessary')
+    })
+
+    afterEach(function () {
+      storeConditionStub.restore()
+    })
+
+    test('with a condition updates the link and calls back', async flags => {
+      const clonedData = {}
+      const withCondition = {
+        updateLink: sinon.stub()
+      }
+      const updatedData = sinon.spy()
+      const savedData = sinon.spy()
+      const onEdit = data => {
+        expect(data.data).to.equal(savedData)
+      }
+      const save = data => {
+        expect(data).to.equal(updatedData)
+        return Promise.resolve(savedData)
+      }
+      // const wrappedOnEdit = flags.mustCall(onEdit, 1)
+
+      const wrapper = shallow(<LinkEdit data={data} edge={edge} onEdit={onEdit} />)
+      const conditions = {}
+      const selectedCondition = {}
+      wrapper.instance().saveConditions(conditions, selectedCondition)
+
+      storeConditionStub.resolves({ data: withCondition, condition: 'aCondition' })
+
+      withCondition.updateLink.returns(updatedData)
+
+      const preventDefault = sinon.spy()
+
+      data.clone = sinon.stub()
+      data.clone.returns(clonedData)
+      data.save = flags.mustCall(save, 1)
+
+      await wrapper.simulate('submit', { preventDefault: preventDefault })
+
+      expect(preventDefault.calledOnce).to.equal(true)
+      expect(storeConditionStub.calledOnce).to.equal(true)
+      expect(storeConditionStub.firstCall.args[0]).to.equal(clonedData)
+      expect(storeConditionStub.firstCall.args[1]).to.equal(selectedCondition)
+      expect(storeConditionStub.firstCall.args[2]).to.equal(conditions)
+
+      expect(withCondition.updateLink.calledOnce).to.equal(true)
+      expect(withCondition.updateLink.firstCall.args[0]).to.equal('/1')
+      expect(withCondition.updateLink.firstCall.args[1]).to.equal('/2')
+      expect(withCondition.updateLink.firstCall.args[2]).to.equal('aCondition')
+    })
+  })
+})

--- a/designer/test/select-conditions.test.js
+++ b/designer/test/select-conditions.test.js
@@ -80,6 +80,23 @@ suite('Select conditions', () => {
         assertLink(selectConditions.find('#inline-conditions-link'), 'inline-conditions-link', 'Define a new condition')
       })
 
+      test('should default the selected condition when one is provided', () => {
+        const wrapper = shallow(<SelectConditions data={data} path={path} selectedCondition={conditions[1].name} conditionsChange={conditionsChange} />)
+        let conditionsSection = wrapper.find('.conditions')
+        expect(conditionsSection.exists()).to.equal(true)
+        let conditionHeaderGroup = conditionsSection.find('#conditions-header-group')
+        expect(conditionHeaderGroup.find('label').text()).to.equal('Conditions (optional)')
+        expect(conditionsSection.find('InlineConditions').exists()).to.equal(false)
+        let selectConditions = conditionsSection.find('#select-condition')
+        expect(selectConditions.exists()).to.equal(true)
+        expect(selectConditions.find('label').text()).to.equal('Select a condition')
+        const expectedFieldOptions = conditions.map(condition => ({ text: condition.displayName, value: condition.name }))
+        expectedFieldOptions.unshift({ text: '' })
+        assertSelectInput(selectConditions.find('select'), 'cond-select',
+          expectedFieldOptions, conditions[1].name)
+        assertLink(selectConditions.find('#inline-conditions-link'), 'inline-conditions-link', 'Define a new condition')
+      })
+
       test('Clicking the define condition link should trigger the inline view to define a condition', () => {
         const wrapper = shallow(<SelectConditions data={data} path={path} conditionsChange={conditionsChange} />)
         expect(wrapper.find('#select-condition').exists()).to.equal(true)
@@ -90,13 +107,27 @@ suite('Select conditions', () => {
         assertInlineConditionsComponent(wrapper, data, path, conditionsChange, true)
       })
 
-      test('cancel inline condition should re-display the select conditions section', () => {
+      test('cancel inline condition should re-display the select conditions section with blank condition', () => {
         const wrapper = shallow(<SelectConditions data={data} path={path} conditionsChange={conditionsChange} />)
         wrapper.find('#inline-conditions-link').simulate('click')
         assertInlineConditionsComponent(wrapper, data, path, conditionsChange, true)
         wrapper.instance().onCancelInlineCondition()
 
-        expect(wrapper.find('#select-condition').exists()).to.equal(true)
+        const expectedFieldOptions = conditions.map(condition => ({ text: condition.displayName, value: condition.name }))
+        expectedFieldOptions.unshift({ text: '' })
+        assertSelectInput(wrapper.find('select'), 'cond-select', expectedFieldOptions, '')
+        expect(wrapper.find('InlineConditions').exists()).to.equal(false)
+      })
+
+      test('cancel inline condition should re-display the select conditions section with specified condition selected', () => {
+        const wrapper = shallow(<SelectConditions data={data} path={path} selectedCondition={conditions[1].name} conditionsChange={conditionsChange} />)
+        wrapper.find('#inline-conditions-link').simulate('click')
+        assertInlineConditionsComponent(wrapper, data, path, conditionsChange, true)
+        wrapper.instance().onCancelInlineCondition()
+
+        const expectedFieldOptions = conditions.map(condition => ({ text: condition.displayName, value: condition.name }))
+        expectedFieldOptions.unshift({ text: '' })
+        assertSelectInput(wrapper.find('select'), 'cond-select', expectedFieldOptions, conditions[1].name)
         expect(wrapper.find('InlineConditions').exists()).to.equal(false)
       })
 

--- a/engine/package-lock.json
+++ b/engine/package-lock.json
@@ -1333,9 +1333,9 @@
       }
     },
     "@babel/runtime": {
-      "version": "7.10.2",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.10.2.tgz",
-      "integrity": "sha512-6sF3uQw2ivImfVIl62RZ7MXhO2tap69WeWK57vAaimT6AZbE4FbqjdEJIN1UqoD6wI6B+1n9UiagafH1sxjOtg==",
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.10.4.tgz",
+      "integrity": "sha512-UpTN5yUJr9b4EX2CnGNWIvER7Ab83ibv0pcvvHc4UOdrBI5jb8bj+32cCwPX6xu0mt2daFNjYhoi+X7beH0RSw==",
       "dev": true,
       "requires": {
         "regenerator-runtime": "^0.13.4"

--- a/engine/package.json
+++ b/engine/package.json
@@ -4,7 +4,6 @@
   "description": "A hapi plugin providing the engine for XGov digital form builder based applications",
   "main": "index.js",
   "module": "src/lib.js",
-  "type": "module",
   "scripts": {
     "fix-lint": "standard --fix",
     "lint": "standard",
@@ -19,6 +18,7 @@
   },
   "license": "SEE LICENSE IN LICENSE",
   "dependencies": {
+    "@babel/runtime": "7.10.4",
     "@hapi/hoek": "^9.0.4",
     "@hapi/joi": "17.1.1",
     "boom": "7.3.0",
@@ -48,7 +48,9 @@
     "joi": "^14"
   },
   "standard": {
-    "ignore": ["lib"],
+    "ignore": [
+      "lib"
+    ],
     "parser": "babel-eslint"
   }
 }

--- a/runner/package-lock.json
+++ b/runner/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "digital-form-builder",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2563,9 +2563,9 @@
       }
     },
     "@babel/runtime": {
-      "version": "7.10.3",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.10.3.tgz",
-      "integrity": "sha512-RzGO0RLSdokm9Ipe/YD+7ww8X2Ro79qiXZF3HU9ljrM+qnJmH1Vqth+hbiQZy761LnMJTMitHDuKVYTk3k4dLw==",
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.10.4.tgz",
+      "integrity": "sha512-UpTN5yUJr9b4EX2CnGNWIvER7Ab83ibv0pcvvHc4UOdrBI5jb8bj+32cCwPX6xu0mt2daFNjYhoi+X7beH0RSw==",
       "dev": true,
       "requires": {
         "regenerator-runtime": "^0.13.4"

--- a/runner/package.json
+++ b/runner/package.json
@@ -28,7 +28,7 @@
   },
   "license": "SEE LICENSE IN LICENSE",
   "dependencies": {
-    "@babel/plugin-transform-classes": "^7.10.1",
+    "@babel/runtime": "7.10.4",
     "@hapi/boom": "9.1.0",
     "@hapi/catbox": "11.1.0",
     "@hapi/catbox-memory": "5.0.0",
@@ -80,6 +80,7 @@
   "devDependencies": {
     "@babel/cli": "7.10.3",
     "@babel/core": "7.10.3",
+    "@babel/plugin-transform-classes": "^7.10.1",
     "@babel/plugin-transform-modules-commonjs": "7.10.1",
     "@babel/plugin-transform-runtime": "7.10.3",
     "@babel/preset-env": "7.10.3",


### PR DESCRIPTION
# Description

Make link-edit consistent with the inline condition builder approach. 

- Wire condition builder into link-edit
- SelectConditions component now supports a default selected condition
- Data class now supports updating a link

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- [X] Unit tests
- [X] Click testing

# Checklist:

- [X] My code follows the [javascript standard style](https://standardjs.com/)
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation and versioning
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I have rebased onto master and there are no code conflicts




